### PR TITLE
Add support to HFTokenzer

### DIFF
--- a/configs/summit-70m-openclipH.yml
+++ b/configs/summit-70m-openclipH.yml
@@ -95,5 +95,6 @@
   "steps_per_print": 10,
   "wall_clock_breakdown": true,
 
-  # "tokenizer-type": "HFTokenizer"
+  "tokenizer-type": "HFTokenizer"
+  # "tokenizer-type": "HFGPT2Tokenizer"
 }

--- a/configs/summit-70m-openclipH.yml
+++ b/configs/summit-70m-openclipH.yml
@@ -1,0 +1,99 @@
+{
+  # image_prefix settings
+  "encoder_name": "openclip-H",
+  # "encoder_name": "nfresnet50",
+  "pretrained_img_encoder": true,
+  "use_image_embed_layernorm": true,
+  "image_embed_dropout_prob": 0.1,
+  # adapter settings
+  "add_adapters": true,
+  "adaper_downsample_factor": 8,
+  "freeze-lm": true,
+  # data resample
+  "dataset_resampled": true,
+
+  # pythia-70m
+  "pipe-parallel-size": 1,
+  "model-parallel-size": 1,
+
+  "num-layers": 6,
+  "hidden-size": 512,
+  "num-attention-heads": 8,
+  "seq-length": 2048,
+  "max-position-embeddings": 2048,
+  "pos-emb": "rotary",
+  "rotary-pct": 0.25,
+  "no-weight-tying": true,
+  "gpt-j-residual": true,
+  "output-layer-parallelism": "column",
+  
+  # "attention-config": [[["flash"], 6]], flash attention not works
+
+  "scaled-upper-triang-masked-softmax-fusion": false,
+  "bias-gelu-fusion": false,
+
+  "init_method": "small_init",
+  "output_layer_init_method": "wang_init",
+
+  "optimizer": {
+    "type": "Adam",
+    "params": {
+      "lr": 0.001,
+      "betas": [0.9, 0.95],
+      "eps": 1.0e-8
+    }
+  },
+  "min_lr": 0.0001,
+
+  "zero_optimization": {
+    "stage": 1,
+    "allgather_partitions": true,
+    "allgather_bucket_size": 500000000,
+    "overlap_comm": true,
+    "reduce_scatter": true,
+    "reduce_bucket_size": 500000000,
+    "contiguous_gradients": true,
+    "cpu_offload": false
+  },
+
+  "train_micro_batch_size_per_gpu": 4,
+  "gas": 1,
+  "data-impl": "mmap",
+  "num_workers": 0,
+
+  "checkpoint-activations": true,
+  "checkpoint-num-layers": 1,
+  "partition-activations": true,
+  "synchronize-each-layer": true,
+
+  "gradient_clipping": 1.0,
+  "weight-decay": 0.1,
+  "hidden-dropout": 0,
+  "attention-dropout": 0,
+
+  "fp16": {
+    "fp16": true,
+    "enabled": true,
+    "loss_scale": 0,
+    "loss_scale_window": 1000,
+    "initial_scale_power": 12,
+    "hysteresis": 2,
+    "min_loss_scale": 1
+  },
+
+  "train-iters": 143000,
+  "lr-decay-iters": 143000,
+  "distributed-backend": "nccl",
+  "lr-decay-style": "cosine",
+  "warmup": 0.01,
+  "checkpoint-factor": 1000,
+  # "extra-save-iters": [0,1,2,4,8,16,32,64,128,256,512],
+  "eval-interval": 100000,
+  "eval-iters": 10,
+
+  "log-interval": 10,
+  "steps_per_print": 10,
+  "wall_clock_breakdown": true,
+
+  # "tokenizer-type": "HFTokenizer"
+}

--- a/configs/summit_setup.yml
+++ b/configs/summit_setup.yml
@@ -1,14 +1,10 @@
 # Suggested data paths when using GPT-NeoX locally
 {
   "train-data-paths": "/gpfs/alpine/csc499/proj-shared/LAION-400m-webdataset/data/{00000..40000}.tar",
-  "valid-data-paths":"/gpfs/alpine/csc499/proj-shared/LAION-400m-webdataset/data/{40001..41000}.tar", 
+  "valid-data-paths": "/gpfs/alpine/csc499/proj-shared/LAION-400m-webdataset/data/{40001..41000}.tar", 
   "test-data-paths": "/gpfs/alpine/csc499/proj-shared/LAION-400m-webdataset/data/{41000..41455}.tar", 
 
-  # If weight_by_num_documents is True, Builds dataset weights from a multinomial distribution over groups of data according to the number of documents in each group.
-  # WARNING: setting this to True will override any user provided weights
-  # "weight_by_num_documents": false,
-  # "weighted_sampler_alpha": 0.3,
-
+  # we use tokenzier from huggingface, don't need vocal or merge file
   #"vocab-file": "/home/lfsm/code/gpt-neox/data/gpt2-vocab.json",
   #"merge-file": "/home/lfsm/code/gpt-neox/data/gpt2-merges.txt",
 
@@ -16,6 +12,8 @@
   
   "save": "/gpfs/alpine/scratch/lfsm/csc499/checkpoints",
   "load": "/gpfs/alpine/scratch/lfsm/csc499/checkpoints",
+  # separate load path for pretrained clip, same with 'load' in this case
+  "load_clip": "/gpfs/alpine/scratch/lfsm/csc499/checkpoints",
   "checkpoint_validation_with_forward_pass": False,
 
   "tensorboard-dir": "/gpfs/alpine/scratch/lfsm/csc499/tensorboard",

--- a/configs/summit_setup.yml
+++ b/configs/summit_setup.yml
@@ -5,10 +5,8 @@
   "test-data-paths": "/gpfs/alpine/csc499/proj-shared/LAION-400m-webdataset/data/{41000..41455}.tar", 
 
   # we use tokenzier from huggingface, don't need vocal or merge file
-  #"vocab-file": "/home/lfsm/code/gpt-neox/data/gpt2-vocab.json",
-  #"merge-file": "/home/lfsm/code/gpt-neox/data/gpt2-merges.txt",
 
-  "tokenizer_type": "HFGPT2Tokenizer",
+  "vocab-file": "./data/20B_tokenizer.json",
   
   "save": "/gpfs/alpine/scratch/lfsm/csc499/checkpoints",
   "load": "/gpfs/alpine/scratch/lfsm/csc499/checkpoints",

--- a/megatron/data/webdataset.py
+++ b/megatron/data/webdataset.py
@@ -330,17 +330,16 @@ def get_wds_data(args, is_train, epoch=0, floor=False):
     preprocess_img = get_clip_transforms(image_size=args.image_size)
     
     assert (
-        args.tokenizer.name in ['HFGPT2Tokenizer','HFGPT2TokenizerFast']
-        ), f"Webdataset only support HFGPT2Tokenizer or HFGPT2TokenizerFast"
+        args.tokenizer.name in ['HFGPT2Tokenizer','HFGPT2TokenizerFast','HFTokenizer']
+        ), f"Webdataset only support HFTokenizer, HFGPT2Tokenizer or HFGPT2TokenizerFast"
     
     tokenize = args.tokenizer.tokenize
-    seq_length = args.seq_length
     
     pipeline.extend([
         wds.select(filter_no_caption_or_no_image),
         wds.decode("pilrgb", handler=log_and_continue),
         wds.rename(image="jpg;png;jpeg;webp", text="txt"),
-        wds.map_dict(image=preprocess_img,  text=lambda text: tokenize(text,seq_length)[0]),
+        wds.map_dict(image=preprocess_img,  text=lambda text: tokenize(text)[0]),
         wds.to_tuple("image", "text"),
         wds.batched(args.batch_size, collation_fn=image_text_dict_collation_fn, partial=not is_train)
     ])

--- a/megatron/data/webdataset.py
+++ b/megatron/data/webdataset.py
@@ -369,7 +369,7 @@ def get_wds_data(args, is_train, epoch=0, floor=False):
         batch_size=None,
         shuffle=False,
         num_workers=args.num_workers,
-        persistent_workers=True,
+        persistent_workers=not (args.num_workers == 0),  # set persistent_workers to false if num_workers is 0
     )
 
     # FIXME not clear which approach is better, with_epoch before vs after dataloader?

--- a/megatron/model/image_prefix.py
+++ b/megatron/model/image_prefix.py
@@ -42,7 +42,7 @@ def nfresnet50(
         *list(timm.create_model(
             "nf_resnet50", 
             pretrained=pretrained,
-            checkpoint_path=cache_path
+            # checkpoint_path=cache_path
             ).children())[:-1]
     )
     pooling = torch.nn.AdaptiveAvgPool2d((1, 1))

--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -297,7 +297,7 @@ class HFGPT2Tokenizer(AbstractTokenizer):
         else:
             self.tokenizer = GPT2Tokenizer.from_pretrained(vocab_name)
 
-        self.tokenizer.add_special_tokens({"pad_token": "<|padding|>","eos_token":"<|endoftext|>"})
+        self.tokenizer.add_special_tokens({"pad_token": "<|padding|>"})
         self.eod_id = self.tokenizer.eos_token_id
         self.pad_id = self.tokenizer.pad_token_id
         self.seq_length = seq_length

--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -19,6 +19,7 @@
 
 from abc import ABC
 from abc import abstractmethod
+import torch
 
 from tokenizers import Tokenizer
 from transformers import GPT2Tokenizer, GPT2TokenizerFast
@@ -43,9 +44,9 @@ def build_tokenizer(args):
         tokenizer = SentencePieceTokenizer(args.vocab_file)
     elif args.tokenizer_type.lower() == "HFTokenizer".lower():
         assert args.vocab_file is not None
-        tokenizer = HFTokenizer(args.vocab_file)
+        tokenizer = HFTokenizer(args.vocab_file,seq_length=args.seq_length)
     elif args.tokenizer_type.lower() == "HFGPT2Tokenizer".lower():
-        tokenizer = HFGPT2Tokenizer()
+        tokenizer = HFGPT2Tokenizer(seq_length=args.seq_length)
     elif args.tokenizer_type.lower() == "CharLevelTokenizer".lower():
         tokenizer = CharLevelTokenizer(vocab_size=512)
     elif args.tokenizer_type.lower() == "TiktokenTokenizer".lower():
@@ -220,13 +221,15 @@ class SentencePieceTokenizer(AbstractTokenizer):
 class HFTokenizer(AbstractTokenizer):
     """Designed to Integrate HF's Tokenizer library."""
 
-    def __init__(self, vocab_file):
+    def __init__(self, vocab_file,seq_length):
         name = "HFTokenizer"
         super().__init__(name)
 
         self.tokenizer = Tokenizer.from_file(vocab_file)
         self.eod_id = self.tokenizer.token_to_id("<|endoftext|>")
         self.pad_id = self.tokenizer.token_to_id("<|padding|>")
+        self.seq_length = seq_length
+        self.tokenizer.enable_truncation(max_length=seq_length)
 
     @property
     def vocab_size(self):
@@ -240,8 +243,20 @@ class HFTokenizer(AbstractTokenizer):
     def inv_vocab(self):
         return self.tokenizer.decoder
 
-    def tokenize(self, text: str):
-        return self.tokenizer.encode(text).ids
+    def tokenize(self, texts: Union[str, List[str]], context_length=2048):
+        if isinstance(texts, str):
+            texts = [texts]
+        texts = [whitespace_clean(basic_clean(text)) for text in texts]
+        input_ids = [encoding.ids for encoding in self.tokenizer.encode_batch(texts)]
+        # add eod_id and pad with pad_id
+        for idx,ids in enumerate(input_ids):
+            if len(ids) < self.seq_length:
+                ids = ids+[self.eod_id]+[self.pad_id]*(self.seq_length-len(ids)-1)
+            else: # truncated
+                ids = ids[:-1]+[self.eod_id]
+            input_ids[idx]=ids
+        input_ids = torch.tensor(input_ids,dtype=torch.int64) 
+        return input_ids
 
     def tokenize_batch(self, text_batch: Union[List[str], str]):
         return self.tokenizer.encode_batch(text_batch)
@@ -271,7 +286,7 @@ def whitespace_clean(text):
 class HFGPT2Tokenizer(AbstractTokenizer):
     """Designed to Integrate the pretrained OpenAI GPT2 Tokenizers from HF"""
 
-    def __init__(self, vocab_file=None, fast=True):
+    def __init__(self, seq_length, fast=True):
         name = "HFGPT2Tokenizer"
         if fast:
             name += "Fast"
@@ -282,9 +297,10 @@ class HFGPT2Tokenizer(AbstractTokenizer):
         else:
             self.tokenizer = GPT2Tokenizer.from_pretrained(vocab_name)
 
-        self.tokenizer.add_special_tokens({"pad_token": "<|padding|>"})
+        self.tokenizer.add_special_tokens({"pad_token": "<|padding|>","eos_token":"<|endoftext|>"})
         self.eod_id = self.tokenizer.eos_token_id
         self.pad_id = self.tokenizer.pad_token_id
+        self.seq_length = seq_length
 
     @property
     def vocab_size(self):
@@ -298,17 +314,23 @@ class HFGPT2Tokenizer(AbstractTokenizer):
     def inv_vocab(self):
         return self.tokenizer._tokenizer.decoder
 
-    def tokenize(self, texts: Union[str, List[str]], context_length=2048):
+    def tokenize(self, texts: Union[str, List[str]]):
         if isinstance(texts, str):
             texts = [texts]
         texts = [whitespace_clean(basic_clean(text)) for text in texts]
         input_ids = self.tokenizer(
             texts,
-            return_tensors='pt',
-            max_length=context_length,
-            padding='max_length',
+            max_length=self.seq_length,
             truncation=True,
         ).input_ids
+        # add eod_id and pad with pad_id
+        for idx,ids in enumerate(input_ids):
+            if len(ids) < self.seq_length:
+                ids = ids+[self.eod_id]+[self.pad_id]*(self.seq_length-len(ids)-1)
+            else: # truncated
+                ids = ids[:-1]+[self.eod_id]
+            input_ids[idx]=ids
+        input_ids = torch.tensor(input_ids,dtype=torch.int64) 
         return input_ids
 
     # def tokenize_batch(self, text_batch: Union[List[str], str]):

--- a/mytests/test_model_build.py
+++ b/mytests/test_model_build.py
@@ -1,16 +1,17 @@
 import os
 import sys
-sys.path.append('/home/lfsm/code/gpt-neox/')
+sys.path.append('.')
 
 import torch
 from megatron.neox_arguments import NeoXArgs
 from megatron.initialize import initialize_megatron
 from megatron.training import setup_model_and_optimizer
 
-neox_args = NeoXArgs.from_ymls(['/home/lfsm/code/gpt-neox/configs/800M.yml', '/home/lfsm/code/gpt-neox/configs/summit_setup.yml'])
+neox_args = NeoXArgs.from_ymls(['./configs/summit-70m-openclipH.yml', './configs/summit_setup.yml'])
 neox_args.configure_distributed_args()
 neox_args.build_tokenizer()  # tokenizer needs to be build in training in order to set the padding vocab
 initialize_megatron(neox_args=neox_args)
 model, optimizer, lr_scheduler = setup_model_and_optimizer(neox_args)
+print(model)
 memory_usage = torch.cuda.memory_allocated() / 1e9
 print("Current GPU memory usage: {:.2f} GB".format(memory_usage))

--- a/prepare_image_prefix.py
+++ b/prepare_image_prefix.py
@@ -4,8 +4,8 @@ sys.path.append('.')
 from megatron.model.image_prefix import ImagePrefix
 from megatron.neox_arguments import NeoXArgs
 
-neox_args = NeoXArgs.from_ymls(['./configs/summit-70m-resnet.yml', './configs/summit_setup.yml'])
-print('')
+
+neox_args = NeoXArgs.from_ymls(['./configs/summit-70m-openclipH.yml', './configs/summit_setup.yml'])
 image_prefix = ImagePrefix(
     config = neox_args,
     out_dim=neox_args.hidden_size,

--- a/prepare_image_prefix.py
+++ b/prepare_image_prefix.py
@@ -1,0 +1,13 @@
+import os
+import sys
+sys.path.append('.')
+from megatron.model.image_prefix import ImagePrefix
+from megatron.neox_arguments import NeoXArgs
+
+neox_args = NeoXArgs.from_ymls(['./configs/summit-70m-resnet.yml', './configs/summit_setup.yml'])
+print('')
+image_prefix = ImagePrefix(
+    config = neox_args,
+    out_dim=neox_args.hidden_size,
+)
+print(f"Downloaded pretrain weight of {neox_args.encoder_name} to {neox_args.load} !")


### PR DESCRIPTION
Add support to HFTokenzer with following changes:
- Modify HFTokenzer to enable tokenzie with truncation and padding.
- Custmize tokenize function of both HFTokenzer and HFGPT2Tokenizer to enable text_token ids followed with eos_id and padding id. If the test_tokens ids length reach out seq_length, then replace the last id with eos_id 
- Move seq_length from variable exposed to tokenzer.tokenze() function to tokenzer class attribute self.seq_length